### PR TITLE
Instruct pip install not to store it's install cache in container image

### DIFF
--- a/scripts/install_dag_in_docker.sh
+++ b/scripts/install_dag_in_docker.sh
@@ -6,6 +6,9 @@ DAGS_PATH=$AIRFLOW_HOME/dags
 REPOS_DIR=$AIRFLOW_HOME/git_repos
 APP_FILES_DIR=$AIRFLOW_HOME/auxiliary_data_pipeline_files
 
+# Reduce size of docker image
+export PIP_NO_CACHE_DIR=1
+
 if [ ! -d $DAGS_PATH ]; then
   mkdir -p $DAGS_PATH
 fi


### PR DESCRIPTION
This saves about 300mb of space from the final image

related to https://github.com/elifesciences/issues/issues/8211