### PR TITLE
Switch to slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.4.2-python3.8
+FROM apache/airflow:slim-2.4.2-python3.8
 ARG GIT_REPO_DIR
 
 USER root


### PR DESCRIPTION
The work on https://github.com/elifesciences/issues/issues/8213 made me come back here and reevaluate the image we're using as a base.

This feels more likely to cause problems and might need a test build to check it does indeed work, but if merged, this will bring the image down to 3.24GB.

relates to https://github.com/elifesciences/issues/issues/8211