### PR TITLE
deps, bumps airflow from 2.4.2 to 2.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.4.2-python3.8
+FROM apache/airflow:2.5.3-python3.8
 ARG GIT_REPO_DIR
 
 USER root

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-apache-airflow[google_auth]==2.4.2
+apache-airflow[google_auth]==2.5.3


### PR DESCRIPTION
Dockerfile, bumps base image from 2.4.2 to 2.5.3.
deps, bumps apache airflow from 2.4.2 to 2.5.3
fixes CVE-2023-25695