### PR TITLE
Removed data-science-dags from repo list

### DIFF
--- a/repo-list.json
+++ b/repo-list.json
@@ -8,10 +8,5 @@
     "git_repo_url": "git@github.com:elifesciences/data-hub-ejp-xml-pipeline.git",
     "reference": "85c69ba5187eaf22f10e364a2930c81b65416340",
     "clone_directory": "ejp_xml_dag"
-  },
-  {
-    "git_repo_url": "git@github.com:elifesciences/data-science-dags.git",
-    "reference": "fd9affcbce51fef81a28b90a3b60becb8affc8e1",
-    "clone_directory": "data_science_dags"
   }
 ]


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1002

We are now running pipelines via Kubernetes Pipeline